### PR TITLE
changed  longToJValueSessionSerializer

### DIFF
--- a/jwt/src/main/scala/com/softwaremill/session/JValueSessionSerializer.scala
+++ b/jwt/src/main/scala/com/softwaremill/session/JValueSessionSerializer.scala
@@ -16,8 +16,8 @@ object JValueSessionSerializer {
   }
 
   implicit def longToJValueSessionSerializer: SessionSerializer[Long, JValue] = new SessionSerializer[Long, JValue] {
-    override def serialize(t: Long) = JInt(t)
-    override def deserialize(s: JValue) = failIfNoMatch(s) { case JInt(v) => v.longValue() }
+    override def serialize(t: Long) = JLong(t)
+    override def deserialize(s: JValue) = failIfNoMatch(s) { case JLong(v) => v.longValue() }
   }
 
   implicit def floatToJValueSessionSerializer: SessionSerializer[Float, JValue] = new SessionSerializer[Float, JValue] {


### PR DESCRIPTION
used JInt type , Json4s provide JLong type , I think is better to JLong then JInt in this case